### PR TITLE
Pin Dockerfile Ruby to 2.3.0 to match Gemfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3
+FROM ruby:2.3.0
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1


### PR DESCRIPTION
Looks like Ruby released 2.3.1 since the convening, and my loose pinning of Ruby to 2.3 in the `Dockerfile` just bit me. It should stay in sync with whatever Ruby version the `Gemfile` says or `bundle install` is gonna be mad.