### PR TITLE
Error messages on initial deploy

### DIFF
--- a/config/initializers/default_host.rb
+++ b/config/initializers/default_host.rb
@@ -5,5 +5,5 @@ begin
     Rails.application.routes.default_url_options[:host] = host
   end
 rescue
-  puts "failed to set default_host, reason: #{$!}"
+  Rails.logger.error "[ERROR] Failed to set default_host. This is expected if this is the very first app deploy."
 end

--- a/config/initializers/default_host.rb
+++ b/config/initializers/default_host.rb
@@ -1,9 +1,11 @@
 begin
   if Rails.application.routes.default_url_options[:host].blank? and AppSetting.default_host_exists?
     host = AppSetting.default_host
-    Rails.logger.info "setting default_host to #{host}"
+    Rails.logger.info "[SUCCESS] Setting default_url_options[:host] = '#{host}'"
     Rails.application.routes.default_url_options[:host] = host
   end
-rescue
-  Rails.logger.error "[ERROR] Failed to set default_host. This is expected if this is the very first app deploy."
+rescue ActiveRecord::NoDatabaseError
+  Rails.logger.error "[ERROR] Failed to set default_host because: ActiveRecord::NoDatabaseError. If this is the first deploy, this is expected and will be fixed after the database is created."
+rescue ActiveRecord::StatementInvalid
+  Rails.logger.error "[ERROR] Failed to set default_host because: ActiveRecord::StatementInvalid. If this is the first deploy, this is expected and will be fixed after the database is migrated."
 end


### PR DESCRIPTION
Cleans up database error messages on very fix deploy, which are expected to happen. After the database is created and migrated, `AppSetting` can correctly (try to) find the setting for Rails.application.routes.default_url_options[:host]. On first deploy, initializing the app will fail without rescuing these exceptions.

Thanks for the catch, @tommeagher