### PR TITLE
AWS SQS integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.3.0'
+ruby '~> 2.3.0'
 
 gem 'rails', '4.2.5.1'
 gem 'pg', '~> 0.15'
@@ -25,6 +25,9 @@ gem 'httparty'
 
 gem 'diffy'
 gem 'kramdown'
+
+# only used for alerting SQS. 
+gem 'aws-sdk', '~> 2.0'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '~> 2.3.0'
+ruby '2.3.0'
 
 gem 'rails', '4.2.5.1'
 gem 'pg', '~> 0.15'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,14 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.4.0)
     arel (6.0.3)
+    aws-sdk (2.6.23)
+      aws-sdk-resources (= 2.6.23)
+    aws-sdk-core (2.6.23)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.6.23)
+      aws-sdk-core (= 2.6.23)
+    aws-sigv4 (1.0.0)
     bcrypt (3.1.11)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
@@ -95,6 +103,7 @@ GEM
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
+    jmespath (1.3.1)
     jquery-rails (4.1.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -267,6 +276,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk (~> 2.0)
   bcrypt (~> 3.1.7)
   byebug
   codeclimate-test-reporter
@@ -298,5 +308,8 @@ DEPENDENCIES
   web-console (~> 2.0)
   webmock
 
+RUBY VERSION
+   ruby 2.3.2p217
+
 BUNDLED WITH
-   1.11.2
+   1.13.6

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -1,5 +1,6 @@
 class IntegrationsController < ApplicationController
   def index
     @slack_integrations = SlackIntegration.all
+    @sqs_integrations = SqsIntegration.all    
   end
 end

--- a/app/controllers/sqs_integrations_controller.rb
+++ b/app/controllers/sqs_integrations_controller.rb
@@ -1,0 +1,58 @@
+class SqsIntegrationsController < ApplicationController
+  before_action :set_sqs_integration, only: [:show, :edit, :update, :destroy]
+
+  # GET /sqs_integrations
+  def index
+    @sqs_integrations = SqsIntegration.all
+  end
+
+  # GET /sqs_integrations/1
+  def show
+  end
+
+  # GET /sqs_integrations/new
+  def new
+    @sqs_integration = SqsIntegration.new
+  end
+
+  # GET /sqs_integrations/1/edit
+  def edit
+  end
+
+  # POST /sqs_integrations
+  def create
+    @sqs_integration = SqsIntegration.new(sqs_integration_params)
+
+    if @sqs_integration.save
+      redirect_to integrations_path, notice: 'SQS integration was successfully created.'
+    else
+      render :new
+    end
+  end
+
+  # PATCH/PUT /sqs_integrations/1
+  def update
+    if @sqs_integration.update(sqs_integration_params)
+      redirect_to integrations_path, notice: 'SQS integration was successfully updated.'
+    else
+      render :edit
+    end
+  end
+
+  # DELETE /sqs_integrations/1
+  def destroy
+    @sqs_integration.destroy
+    redirect_to integrations_path, notice: 'SQS integration was successfully destroyed.'
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_sqs_integration
+      @sqs_integration = SqsIntegration.find(params[:id])
+    end
+
+    # Only allow a trusted parameter "white list" through.
+    def sqs_integration_params
+      params.require(:sqs_integration).permit(:queue_url)
+    end
+end

--- a/app/lib/sqs_notification.rb
+++ b/app/lib/sqs_notification.rb
@@ -27,6 +27,3 @@ class SqsNotification
     end
   end
 end
-
-
-

--- a/app/lib/sqs_notification.rb
+++ b/app/lib/sqs_notification.rb
@@ -1,0 +1,32 @@
+require 'aws-sdk'
+
+class SqsNotification
+  def self.perform(queue_url, payload)
+    client = Aws::SQS::Client.new(
+      access_key_id: ENV["AWS_ACCESS_KEY_ID"] || ENV["ACCESS_KEY_ID"],
+      secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"] || ENV["SECRET_ACCESS_KEY"],
+      region: 'us-east-1'
+    )
+    json = payload.to_json
+
+    begin
+      return client.send_message({
+        delay_seconds: 10, 
+        message_attributes: {
+          "payload" => {
+            data_type: "String", 
+            string_value: json, 
+          }
+        }, 
+        message_body: json, 
+        queue_url: queue_url, 
+      }) 
+    rescue Aws::SQS::Errors::ServiceError => e
+      puts "Error sending SQS message to queue_url=#{queue_url} for payload=#{payload.to_json}; Error: #{e}"
+      return false
+    end
+  end
+end
+
+
+

--- a/app/models/change.rb
+++ b/app/models/change.rb
@@ -30,6 +30,10 @@ class Change < ActiveRecord::Base
     subscriptions.all.map do |subscription|
       subscription.send_notification(self)
     end
+
+    # unlike people and slack channels, there are no "subscriptions" to SQS integrations,
+    # instead, all changes are sent to the queue -- allowing the consumer to choose which to act on
+    SqsIntegration.all.each{|sqs_integration| sqs_integration.send_notification(self) }
   end
 
   def self.check

--- a/app/models/sqs_integration.rb
+++ b/app/models/sqs_integration.rb
@@ -11,7 +11,7 @@ class SqsIntegration < ActiveRecord::Base
   include Rails.application.routes.url_helpers
 
   def send_notification(change)
-    puts "slack_integration#send_notification #{self.queue_url}"
+    puts "sqs_integration#send_notification #{self.queue_url}"
 
     page_name = change&.after&.page&.name
     text = "#{page_name} changed #{change&.after&.page&.url}"

--- a/app/models/sqs_integration.rb
+++ b/app/models/sqs_integration.rb
@@ -1,0 +1,35 @@
+class SqsIntegration < ActiveRecord::Base
+
+  validates :queue_url, length: { minimum: 10 }
+  validate :starts_with_https
+  def starts_with_https
+    if queue_url.to_s.split('').first(5).join('') != 'https'
+      errors.add(:queue_url, "must begin with https")
+    end
+  end
+
+  include Rails.application.routes.url_helpers
+
+  def send_notification(change)
+    puts "slack_integration#send_notification #{self.queue_url}"
+
+    page_name = change&.after&.page&.name
+    text = "#{page_name} changed #{change&.after&.page&.url}"
+
+    payload = {
+      "page_name": page_name,
+      "text": text,
+      "change_page_url": page_change_url(change),
+
+      "url": change&.after&.page&.url,
+      "event": "update",
+      "source": "klaxon",
+      "type": "external",
+      "eventTS": Time.now.to_i
+    }
+
+    SqsNotification.perform(self.queue_url, payload)
+    return payload
+  end
+
+end

--- a/app/views/integrations/index.html.erb
+++ b/app/views/integrations/index.html.erb
@@ -29,6 +29,14 @@
       	<%= link_to "Create Slack Integration", new_slack_integration_path,class: 'btn btn-default btn-lg btn-block' %>
       </div>
     </div>
+    <div class="row">
+      <div class="col-md-9">
+          <h4 style="margin-top: 0;" class="klax-spacer-md">SQS</h4>
+      </div>
+      <div class="col-md-3">
+        <%= link_to "Create SQS Integration", new_sqs_integration_path,class: 'btn btn-default btn-lg btn-block' %>
+      </div>
+    </div>    
     <% if @slack_integrations.present? %>
     <table class="table">
       <thead>
@@ -48,6 +56,26 @@
       </tbody>
     </table>
     <% end %>
+    <% if @sqs_integrations.present? %>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Queue URL</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @sqs_integrations.each do |integration| %>
+        <tr>
+          <td><%= integration.queue_url %></td>
+          <td><%= link_to "Edit", edit_sqs_integration_path(integration),class: 'btn btn-default btn-block pull-right', style: "max-width: 136px !important;" %>
+        </td>
+        </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <% end %>
+
 
   </div>
 </div>

--- a/app/views/integrations/index.html.erb
+++ b/app/views/integrations/index.html.erb
@@ -29,14 +29,6 @@
       	<%= link_to "Create Slack Integration", new_slack_integration_path,class: 'btn btn-default btn-lg btn-block' %>
       </div>
     </div>
-    <div class="row">
-      <div class="col-md-9">
-          <h4 style="margin-top: 0;" class="klax-spacer-md">SQS</h4>
-      </div>
-      <div class="col-md-3">
-        <%= link_to "Create SQS Integration", new_sqs_integration_path,class: 'btn btn-default btn-lg btn-block' %>
-      </div>
-    </div>    
     <% if @slack_integrations.present? %>
     <table class="table">
       <thead>
@@ -56,6 +48,14 @@
       </tbody>
     </table>
     <% end %>
+    <div class="row">
+      <div class="col-md-9">
+          <h4 style="margin-top: 0;" class="klax-spacer-md">SQS</h4>
+      </div>
+      <div class="col-md-3">
+        <%= link_to "Create SQS Integration", new_sqs_integration_path,class: 'btn btn-default btn-lg btn-block' %>
+      </div>
+    </div>        
     <% if @sqs_integrations.present? %>
     <table class="table">
       <thead>

--- a/app/views/sqs_integrations/_form.html.erb
+++ b/app/views/sqs_integrations/_form.html.erb
@@ -1,0 +1,33 @@
+<%= simple_form_for(@sqs_integration) do |f| %>
+  <%= f.error_notification %>
+
+<div class="klax-section klax-spacer-lg">
+  <div class="container">
+    <div class="row klax-spacer-md">
+      <div class="col-md-12">
+        <h4>Details</h4>
+      </div>
+    </div>
+    <div class="row">
+      <form class="form-horizontal">
+        <div class="form-group form-group-lg">
+          <label class="col-sm-1">Queue URL</label>
+          <div class="col-sm-11">
+            <%= f.input :queue_url, label: false, class: 'form-control' %>
+          </div>
+        </div>
+
+        <div class="form-group form-group-lg">
+          <div class="col-md-9">
+            <!-- negative space -->
+          </div>
+          <div class="col-md-3">
+            <%= f.button :submit, "Create SQS Integration", class: "btn btn-default btn-lg btn-block" %>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div><!-- /.container -->
+</div>
+
+<% end %>

--- a/app/views/sqs_integrations/edit.html.erb
+++ b/app/views/sqs_integrations/edit.html.erb
@@ -1,0 +1,22 @@
+<div class="klax-section klax-topper">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+        <h1>Editing SQS Integration</h1>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-6">
+      <p class="lead">Integrations allow you to push alerts to various platforms. For now, Klaxon supports Slack and Amazon SQS. We hope to add more in the future. If you’re interested in helping, <a href="https://github.com/themarshallproject/klaxon">visit our repo.</a></p>
+      </div>
+      <div class="col-md-3">
+        <!-- negative space -->
+      </div>
+      <div class="col-md-3">
+        <%= link_to 'Delete? It’s Permanent.', @slack_integration, method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-default btn-lg btn-block" %>
+      </div>
+    </div>
+  </div><!-- /.container -->
+</div>
+
+<%= render 'form' %>

--- a/app/views/sqs_integrations/index.html.erb
+++ b/app/views/sqs_integrations/index.html.erb
@@ -1,0 +1,27 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Listing SQS Integrations</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Queue url</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @sqs_integrations.each do |sqs_integration| %>
+      <tr>
+        <td><%= sqs_integration.queue_url %></td>
+        <td><%= link_to 'Show', sqs_integration %></td>
+        <td><%= link_to 'Edit', edit_sqs_integration_path(sqs_integration) %></td>
+        <td><%= link_to 'Destroy', sqs_integration, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New SQS integration', new_sqs_integration_path %>

--- a/app/views/sqs_integrations/new.html.erb
+++ b/app/views/sqs_integrations/new.html.erb
@@ -1,0 +1,18 @@
+<div class="klax-section klax-topper">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+        <h1>New SQS Integration</h1>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-6">
+      <p class="lead">Integrations allow you to push alerts to various platforms. For now, Klaxon supports Slack and Amazon SQS. We hope to add more in the future. If you’re interested in helping, <a href="https://github.com/themarshallproject/klaxon">visit our repo.</a></p>
+      </div>
+      <div class="col-md-6">
+        <!-- negative space -->
+      </div>
+    </div>
+  </div><!-- /.container -->
+</div>
+<%= render 'form' %>

--- a/app/views/sqs_integrations/show.html.erb
+++ b/app/views/sqs_integrations/show.html.erb
@@ -1,0 +1,9 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>SQS Queue url:</strong>
+  <%= @sqs_integration.queue_url %>
+</p>
+
+<%= link_to 'Edit', edit_sqs_integration_path(@sqs_integration) %> |
+<%= link_to 'Back', sqs_integrations_path %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,8 +81,9 @@ Rails.application.configure do
 
   provider  = (ENV["SMTP_PROVIDER"] || "SENDGRID").to_s
   address   = ENV["#{provider}_ADDRESS"] || "smtp.sendgrid.net"
-  user_name = ENV["#{provider}_USERNAME"]
-  password  = ENV["#{provider}_PASSWORD"]
+              # if you use SES as your SMTP provider, then your username and password are actually your AWS credentials.
+  user_name = ENV["#{provider}_USERNAME" || (provider == "SES" ? (ENV["AWS_ACCESS_KEY_ID"] || ENV["ACCESS_KEY_ID"] ) : nil) ]  # for AWS SES, this is your access key id
+  password  = ENV["#{provider}_PASSWORD" || (provider == "SES" ? (ENV["AWS_SECRET_ACCESS_KEY"] || ENV["SECRET_ACCESS_KEY"] ) : nil) ]  # for AWS SES, this is your secret access key 
   domain    = ENV["#{provider}_DOMAIN"] || "heroku.com"
 
   ActionMailer::Base.smtp_settings = {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,7 +81,7 @@ Rails.application.configure do
 
   provider  = (ENV["SMTP_PROVIDER"] || "SENDGRID").to_s
   address   = ENV["#{provider}_ADDRESS"] || "smtp.sendgrid.net"
-              # if you use SES as your SMTP provider, then your username and password are actually your AWS credentials.
+  # if you use SES as your SMTP provider, then your username and password are actually your AWS credentials.
   user_name = ENV["#{provider}_USERNAME" || (provider == "SES" ? (ENV["AWS_ACCESS_KEY_ID"] || ENV["ACCESS_KEY_ID"] ) : nil) ]  # for AWS SES, this is your access key id
   password  = ENV["#{provider}_PASSWORD" || (provider == "SES" ? (ENV["AWS_SECRET_ACCESS_KEY"] || ENV["SECRET_ACCESS_KEY"] ) : nil) ]  # for AWS SES, this is your secret access key 
   domain    = ENV["#{provider}_DOMAIN"] || "heroku.com"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
   scope '/integrations' do
     get '/' => 'integrations#index', as: :integrations
     resources :slack, as: 'slack_integrations', controller: 'slack_integrations'
+    resources :sqs, as: 'sqs_integrations', controller: 'sqs_integrations'    
   end
 
   get '/help' => 'static#help', as: :help

--- a/db/migrate/20161117114700_create_sqs_integrations.rb
+++ b/db/migrate/20161117114700_create_sqs_integrations.rb
@@ -1,0 +1,9 @@
+class CreateSqsIntegrations < ActiveRecord::Migration
+  def change
+    create_table :sqs_integrations do |t|
+      t.text :queue_url
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160418211250) do
+ActiveRecord::Schema.define(version: 20161117114700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,6 +68,12 @@ ActiveRecord::Schema.define(version: 20160418211250) do
     t.text     "webhook_url"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+  end
+
+  create_table "sqs_integrations", force: :cascade do |t|
+    t.text     "queue_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "subscriptions", force: :cascade do |t|


### PR DESCRIPTION
Hey friends,

I've added Amazon SQS integration to our internal Klaxon. This PR isn't quite ready (I haven't written tests yet and some kinks will likely pop up in real-life usage), but I wanted to get y'all's feedback beforehand. 

In particular, I want to call your attention to the "payload" of data sent to SQS. Everybody's SQS use-case will be different, so we can't please everyone. However, what I've submitted covers, I think, all the data points that you might conceivably want, with a defensible set of names for the keys. (Conveniently, of course, it's what our internal SQS consumer uses, but ya gotta start somewhere... 😄 ) What do you think?

An alternative would be to create a field where users can set their own format for the payload, but that seems likely to cause trouble, because you'd have to validate the format, make sure it `eval`s successfully, etc. 

Another outstanding piece of this: we should probably also trigger sending a notification to SQS when a Page is first added to Klaxon to be watched, as a "before" to the eventual "after".