### PR TITLE
Enable closing of bookmarklet

### DIFF
--- a/app/views/embed/iframe.html.erb
+++ b/app/views/embed/iframe.html.erb
@@ -87,6 +87,15 @@ a {
   font-size: 14px;
   padding: 20px;
 }
+
+#klax-close-bookmarklet {
+  color: #a0a0a0;
+  float: right;
+  font-size: 18px;
+}
+#klax-close-bookmarklet:hover {
+  color: #ff0b3a;
+}
 </style>
 <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
 </head>
@@ -94,6 +103,7 @@ a {
 
 <div class="container">
 
+  <div id="klax-close-bookmarklet">✖</div>
   <div class="klax-app-name">Klaxon</div>
   <p class="klax-lead">Hover over the page and click the item you want to watch. Preview it below to make sure you’ve selected the correct item.</p>
 
@@ -171,6 +181,10 @@ a {
     });
   };
 
+  var closeKlaxonBookmarklet = function() {
+    parent.window.postMessage("close_klaxon_bookmarklet", "*");
+  }
+  document.getElementById("klax-close-bookmarklet").addEventListener('click', closeKlaxonBookmarklet, false);
   </script>
 
 </body>

--- a/app/views/embed/inject.js.erb
+++ b/app/views/embed/inject.js.erb
@@ -60,6 +60,7 @@
   var src = editorURL + "?url=" + encodeURIComponent(getCanonicalURL());
   var iframe = document.createElement('iframe');
   iframe.setAttribute('src', src);
+  iframe.setAttribute('id', 'klaxon-bookmarklet-iframe');
   iframe.setAttribute('frameborder', 0);
   iframe.style.top = '0px';
   iframe.style.right = '0px';
@@ -99,15 +100,31 @@
   }
 
   window.addEventListener('click', function(evt) {
-    evt.preventDefault();
-    postMessage({ event: 'click' });
+    if (window._klaxonInject === true) {
+      evt.preventDefault();
+      postMessage({ event: 'click' });
+    }
   });
 
   window.addEventListener('mousemove', function(evt) {
-    var x = evt.clientX;
-    var y = evt.clientY;
-    var el = document.elementFromPoint(x, y);
-    updatePath(cssPath(el));
+    if (window._klaxonInject === true) {
+      var x = evt.clientX;
+      var y = evt.clientY;
+      var el = document.elementFromPoint(x, y);
+      updatePath(cssPath(el));
+    }
   });
 
+  var receiveMessage = function(event){
+   if (event.data=="close_klaxon_bookmarklet"){
+      var iframe = document.getElementById('klaxon-bookmarklet-iframe');
+      iframe.parentNode.removeChild(iframe);
+      var style = document.getElementById('klaxon-css-inject');
+      style.parentNode.removeChild(style);
+      console.log("Closed Klaxon Bookmarklet")
+      window._klaxonInject = false;
+   }
+  }
+
+  window.addEventListener("message", receiveMessage, false);
 })();


### PR DESCRIPTION
This PR addresses issue #31 - Cancel/close the bookmarklet

It adds a "close" ✖ button to `app/views/embed/iframe.html.erb` (shown in the image below) and an EventListener to ` app/views/embed/inject.js.erb` that removes the bookmarklet's iframe and style elements when a user clicks the "close" button. 

<img width="436" alt="screen shot 2016-12-26 at 12 09 33 pm" src="https://cloud.githubusercontent.com/assets/4183377/21484739/a05ccdee-cb65-11e6-8356-ffad746a6414.png">

This change enables a user to open and close the bookmarklet multiple times on a single page, without affecting the bookmarklet's functionality. A gif of this process in action is available [here](https://dl.dropboxusercontent.com/s/excyyj9oirll1f4/A8C4DABA-31AC-4694-88A7-F0162D865AAB-4708-000024459DA69477.gif?dl=0)
