### PR TITLE
reliably sort pages in watching

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -24,7 +24,7 @@ class PagesController < ApplicationController
 
   # GET /pages
   def index
-    @pages = Page.order(:created_at).all
+    @pages = Page.order('created_at DESC').all
   end
 
   # GET /pages/1

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -24,7 +24,7 @@ class PagesController < ApplicationController
 
   # GET /pages
   def index
-    @pages = Page.all
+    @pages = Page.order(:created_at).all
   end
 
   # GET /pages/1


### PR DESCRIPTION
Hey y'all... Another PR from me!

A ton of folks have picked up Klaxon this week, so the number of pages that we're "watching" is increasing. I noticed that when a new site was watched, where it showed up in the list wasn't predictable. Klaxon doesn't appear to sort them at all, so I made this little tweak to sort them oldest first.