### PR TITLE
Update Docker guide to include Amazon SES

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -13,3 +13,17 @@ ADMIN_EMAILS=
 SENDGRID_USERNAME=
 SENDGRID_PASSWORD=
 ```
+
+If you would like to use [Amazon SES](https://aws.amazon.com/ses/) instead to send emails, you'll need a different set of environmental variables.
+
+```sh
+DATABASE_URL=
+SECRET_KEY_BASE=
+ADMIN_EMAILS=
+SMTP_PROVIDER=AMAZON_SES
+AMAZON_SES_ADDRESS=
+AMAZON_SES_USERNAME=
+AMAZON_SES_PASSWORD=
+AMAZON_SES_DOMAIN=
+EMAIL_FROM_ADDRESS=
+```


### PR DESCRIPTION
When I originally punched in this quick guide, I for some reason left it to only detail how to use SendGrid, even though our usage of it leaned on Amazon SES.

I know very little of how ActionMailer (or Rails, or even Ruby, honestly) works, so maybe this is too specific. 😛 But I figured it may help someone else.