### PR TITLE
adds the ability to set the SES port via env var

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -85,10 +85,11 @@ Rails.application.configure do
   user_name = ENV["#{provider}_USERNAME" || (provider == "SES" ? (ENV["AWS_ACCESS_KEY_ID"] || ENV["ACCESS_KEY_ID"] ) : nil) ]  # for AWS SES, this is your access key id
   password  = ENV["#{provider}_PASSWORD" || (provider == "SES" ? (ENV["AWS_SECRET_ACCESS_KEY"] || ENV["SECRET_ACCESS_KEY"] ) : nil) ]  # for AWS SES, this is your secret access key 
   domain    = ENV["#{provider}_DOMAIN"] || "heroku.com"
+  port      = ENV["#{provider}_PORT"] || "587"
 
   ActionMailer::Base.smtp_settings = {
     :address        => address,
-    :port           => '587',
+    :port           => port,
     :authentication => :plain,
     :user_name      => user_name,
     :password       => password,


### PR DESCRIPTION
my previous pull request allowed a user to send emails with Amazon SES instead of Sendgrid. It recently became necessary for me to be able to set the SMTP port, so this just adds that option, along the same lines as the previous setup.