### PR TITLE
Add config to restrict user email address domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Once you’re logged in, you should see the main page that will fill up in the c
 
 On the right side of the page, click the “Create New User” button. Add the reporter’s first and last name and email address, and she will get an email allowing her into the Klaxon. Now, finally, you and your users can start adding web pages you want Klaxon to watch.
 
+#### Limit new users to only those on specific email domain(s)
+
+By default, people with any email address can be added as new users. If you'd like to allow only users with *specific* email domains, set the `APPROVED_USER_DOMAINS` environment variable (or "Config Variable" in Heroku's lingo). That variable should be a comma-separated list of domains, e.g., `themarshallproject.org,nsa.gov`.
+
 ### Notify a Slack channel
 
 You’re all set for email notifications. If you’d like to also receive alerts through Slack, you can set that up now too. (If you want alerts from other services, [we welcome pull requests](CONTRIBUTING.md)) Click on the “Settings” button in the upper right corner of the page and choose “Integrations” from the menu. On the Integrations page, click the “Create Slack Integration” button. You can add an integration for any number of channels in your newsroom’s Slack. For each one, you just have to set up an Incoming Webhook. In Slack, click on the dropdown arrow in the upper left corner and choose “Apps & Integrations” from the menu. This will open a new window in your browser for you to search the Slack app directory. In the search box, type “Incoming Webhooks” and choose that option when it pops up. If you already have webhooks, you’ll see a button next to your Slack organization’s name that says “Configure.” Otherwise, click the green button that says “Install”.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,23 +26,13 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
 
-    user_domain = @user.email.strip.split('@')[-1].downcase
+    if @user.save
+      UserMailer.welcome_email(user: @user, invited_by: current_user).deliver_later
 
-    approved_domains = (ENV['APPROVED_USER_DOMAINS'] || '').strip.downcase.split(',')
-    approve_any_domain = approved_domains.length == 0
-    domain_is_approved = approved_domains.include?(user_domain)
-
-    if approve_any_domain or domain_is_approved
-      if @user.save
-        UserMailer.welcome_email(user: @user, invited_by: current_user).deliver_later
-        redirect_to users_url, notice: 'User was successfully created.'
-      else
-        render :new
-      end
+      redirect_to users_url, notice: 'User was successfully created.'
     else
-      redirect_to users_url, notice: 'User\'s email address belongs to non-approved domain.'
+      render :new
     end
-
   end
 
   # PATCH/PUT /users/1

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,13 +26,23 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
 
-    if @user.save
-      UserMailer.welcome_email(user: @user, invited_by: current_user).deliver_later
+    user_domain = @user.email.strip.split('@')[-1].downcase
 
-      redirect_to users_url, notice: 'User was successfully created.'
+    approved_domains = (ENV['APPROVED_USER_DOMAINS'] || '').strip.downcase.split(',')
+    approve_any_domain = approved_domains.length == 0
+    domain_is_approved = approved_domains.include?(user_domain)
+
+    if approve_any_domain or domain_is_approved
+      if @user.save
+        UserMailer.welcome_email(user: @user, invited_by: current_user).deliver_later
+        redirect_to users_url, notice: 'User was successfully created.'
+      else
+        render :new
+      end
     else
-      render :new
+      redirect_to users_url, notice: 'User\'s email address belongs to non-approved domain.'
     end
+
   end
 
   # PATCH/PUT /users/1

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,6 +39,11 @@ class User < ActiveRecord::Base
   end
 
   def email_domain_is_approved
+    if not (email || '').include?('@')
+      errors.add(:email, 'Email address is invalid.')
+      return false
+    end
+
     user_domain = email.strip.split('@')[-1].downcase
     approved_domains = (ENV['APPROVED_USER_DOMAINS'] || '').strip.downcase.split(',')
 
@@ -46,7 +51,8 @@ class User < ActiveRecord::Base
     domain_is_approved = approved_domains.include?(user_domain)
 
     if not (approve_any_domain or domain_is_approved)
-      errors.add(:email, 'This email address belongs to a non-approved domain.')
+      errors.add(:email, 'Email address belongs to a non-approved domain.')
+      return false
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -15,7 +15,7 @@ FactoryGirl.define do
 
   factory :sqs_integration do
     queue_url "https://sqs.us-east-1.amazonaws.com/1234567890/klaxon-sqs-q-test"
-  end  
+  end
 
   factory :change do
   end

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -2,11 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "users/edit", type: :view do
   before(:each) do
-    @user = assign(:user, User.create!(
-      :first_name => "MyString",
-      :last_name => "MyString",
-      :email => "MyString"
-    ))
+    @user = create(:user)
   end
 
   it "renders the edit user form" do

--- a/spec/views/users/show.html.erb_spec.rb
+++ b/spec/views/users/show.html.erb_spec.rb
@@ -2,17 +2,13 @@ require 'rails_helper'
 
 RSpec.describe "users/show", type: :view do
   before(:each) do
-    @user = assign(:user, User.create!(
-      :first_name => "First Name",
-      :last_name => "Last Name",
-      :email => "Email"
-    ))
+    @user = create(:user)
   end
 
   it "renders attributes in <p>" do
     render
-    expect(rendered).to match(/First Name/)
-    expect(rendered).to match(/Last Name/)
+    expect(rendered).to match(/First/)
+    expect(rendered).to match(/Last/)
     expect(rendered).to match(/Email/)
   end
 end


### PR DESCRIPTION
Enables the following functionality, per this proposed addition to `README.md`:

> By default, people with any email address can be added as new users. If you'd like to allow only users with specific email domains, set the `APPROVED_USER_DOMAINS` environment variable (or "Config Variable" in Heroku's lingo). That variable should be a comma-separated list of domains, e.g., `themarshallproject.org,nsa.gov`.

Note: The new code invokes `redirect_to users_url notice: 'User\'s email address belongs to non-approved domain.'`, but notices don't seem to be reflected on the `/users` endpoint. So currently, you won't see any indication that Klaxon rejected your attempt to add a new user because of that users' email address. The user simply doesn't show up on the users list.