### PR TITLE
Delete user feature for admin users

### DIFF
--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -86,6 +86,10 @@ table tbody tr td:last-child, table thead tr td:last-child  {
   color: #ff0b3a;
 }
 
+.form-check-box {
+  margin-bottom: 10px !important;
+}
+
 .btn {
   border-radius: 0 !important;
   border: 1px solid #ff0b3a;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -39,6 +39,11 @@ class UsersController < ApplicationController
 
   # PATCH/PUT /users/1
   def update
+    if user_params[:is_admin] && !@user.is_admin && !current_user.is_admin
+      redirect_to edit_user_url(@user), notice: 'You must be an admin to promote users.'
+      return false
+    end
+
     if @user.update(user_params)
       redirect_to users_url, notice: 'User was successfully updated.'
     else
@@ -48,6 +53,11 @@ class UsersController < ApplicationController
 
   # DELETE /users/1
   def destroy
+    unless current_user.is_admin
+      redirect_to edit_user_url(@user), notice: 'You must be an admin to delete users.'
+      return false
+    end
+
     @user.subscriptions.destroy_all
     @user.destroy
     redirect_to users_url, notice: 'User was successfully deleted.'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,6 +46,7 @@ class UsersController < ApplicationController
 
   # DELETE /users/1
   def destroy
+    @user.subscriptions.destroy_all
     @user.destroy
     redirect_to users_url, notice: 'User was successfully deleted.'
   end
@@ -58,6 +59,6 @@ class UsersController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def user_params
-      params.require(:user).permit(:first_name, :last_name, :email)
+      params.require(:user).permit(:first_name, :last_name, :email, :is_admin)
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,10 +16,12 @@ class UsersController < ApplicationController
   # GET /users/new
   def new
     @user = User.new
+    @current_user = current_user
   end
 
   # GET /users/1/edit
   def edit
+    @current_user = current_user
   end
 
   # POST /users

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -32,7 +32,7 @@
         <div class="form-group form-group-lg">
           <label class="col-sm-1">Admin</label>
           <div class="col-sm-11">
-            <%= f.check_box :is_admin, label: false, class: 'form-control' %>
+            <%= f.check_box :is_admin, label: false, class: 'form-check-box' %>
           </div>
         </div>
         <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -28,6 +28,14 @@
             <%= f.input :email, label: false, class: 'form-control' %>
           </div>
         </div>
+        <% if current_user.is_admin %>
+        <div class="form-group form-group-lg">
+          <label class="col-sm-1">Admin</label>
+          <div class="col-sm-11">
+            <%= f.check_box :is_admin, label: false, class: 'form-control' %>
+          </div>
+        </div>
+        <% end %>
         <div class="form-group form-group-lg">
           <div class="col-md-9">
             <!-- negative space -->

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -28,7 +28,7 @@
             <%= f.input :email, label: false, class: 'form-control' %>
           </div>
         </div>
-        <% if current_user.is_admin %>
+        <% if @current_user.is_admin %>
         <div class="form-group form-group-lg">
           <label class="col-sm-1">Admin</label>
           <div class="col-sm-11">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -12,7 +12,7 @@
       <div class="col-md-3">
       </div>
       <div class="col-md-3">
-        <% if current_user.is_admin %>
+        <% if @current_user.is_admin %>
           <%= link_to 'Delete? It’s Permanent.', @user, method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-default btn-lg btn-block" %>
         <% end %>
       </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -12,6 +12,9 @@
       <div class="col-md-3">
       </div>
       <div class="col-md-3">
+        <% if current_user.is_admin %>
+          <%= link_to 'Delete? It’s Permanent.', @user, method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-default btn-lg btn-block" %>
+        <% end %>
       </div>
     </div>
   </div><!-- /.container -->

--- a/db/migrate/20170526193719_add_is_admin_to_user.rb
+++ b/db/migrate/20170526193719_add_is_admin_to_user.rb
@@ -1,0 +1,5 @@
+class AddIsAdminToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :is_admin, :boolean
+  end
+end

--- a/db/migrate/20170526193719_add_is_admin_to_user.rb
+++ b/db/migrate/20170526193719_add_is_admin_to_user.rb
@@ -1,5 +1,31 @@
 class AddIsAdminToUser < ActiveRecord::Migration
   def change
     add_column :users, :is_admin, :boolean
+    
+    # Set new `is_admin` field for users listed in the `ADMIN_EMAILS`
+    # environment variable, if it exists
+    emails = ENV['ADMIN_EMAILS'].to_s.split(',')
+    emails.each do |email|
+      email.strip!
+      user = User.where(email: email).first_or_create do |user|
+        puts "ENV['ADMIN_EMAILS']: creating user with email='#{user.email}'"
+      end
+      user.is_admin = true
+      user.save
+    end
+    
+    # The below only should apply to people hosting Klaxon themselves rather
+    # than on Heroku, and only in certain situations.
+    if emails.empty?
+      puts <<~EOF
+        Your ADMIN_EMAILS environment variable was empty.
+        
+        If you want to be able to delete users from within the Klaxon
+        Web interface, set up at least one admin user.
+        
+        The easiest way to do this is to run the "users:create_admin"
+        Rake task with the ADMIN_EMAILS environment variable set.
+      EOF
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161117114700) do
+ActiveRecord::Schema.define(version: 20170526193719) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,6 +96,7 @@ ActiveRecord::Schema.define(version: 20161117114700) do
     t.string   "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean  "is_admin"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", using: :btree

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -4,9 +4,11 @@ namespace :users do
     emails = ENV['ADMIN_EMAILS'].to_s.split(',')
     emails.each do |email|
       email.strip!
-      User.where(email: email).first_or_create do |user|
+      user = User.where(email: email).first_or_create do |user|
         puts "ENV['ADMIN_EMAILS']: creating user with email='#{user.email}'"
       end
+      user.is_admin = true
+      user.save
     end
   end
 

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe "users/edit", type: :view do
   before(:each) do
     @user = create(:user)
+    @current_user = @user
   end
 
   it "renders the edit user form" do

--- a/spec/views/users/new.html.erb_spec.rb
+++ b/spec/views/users/new.html.erb_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "users/new", type: :view do
       :last_name => "MyString",
       :email => "MyString"
     ))
+    @current_user = create(:user)
   end
 
   it "renders new user form" do


### PR DESCRIPTION
This pull request will allow users set up as admins to delete users. It removes any subscriptions assigned to that user too.

I've modified the users:create_admin rake task and the db migration so that it uses the ADMIN_EMAILS environmental variable for to populate the is_admin field in the users table. It sets a boolean value of true if the user has been assigned as an admin.

Changes:
adds is_admin field to user table migration
automatically deletes a user's subscriptions when deleting a user
adds a delete button viewable only by users assigned as an admin
adds css to style new is_admin checkbox form
modified rake task to assign admin users as true in new is_admin field in user table.