### PR TITLE
do not add bottom border on hover when link is also a button. Fixes #125

### DIFF
--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -12,7 +12,7 @@ a {
   border-bottom: 2px solid #ff0b3a;
 }
 
-a:hover, a:focus {
+a:not(.btn):hover, a:focus {
   color: #ff0b3a;
   text-decoration: none;
   border-bottom: 2px solid #ff0b3a;


### PR DESCRIPTION
Don't apply link hover style when the element being hovered on is a `.btn` 