### PR TITLE
Replace FactoryGirl with FactoryBot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ group :development, :test do
   gem 'byebug'
   gem 'rspec-rails', '~> 3.0'
   gem 'guard-rspec', require: false
-  gem 'factory_girl_rails', '~> 4.0'
+  gem 'factory_bot_rails', '~> 4.0'
   gem 'database_cleaner'
   gem 'sinatra'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,10 +75,10 @@ GEM
     dotenv (2.5.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    factory_girl (4.7.0)
+    factory_bot (4.11.0)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.7.0)
-      factory_girl (~> 4.7.0)
+    factory_bot_rails (4.11.0)
+      factory_bot (~> 4.11.0)
       railties (>= 3.0.0)
     ffi (1.9.10)
     formatador (0.2.5)
@@ -117,7 +117,7 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.4.1)
       launchy (~> 2.2)
-    libv8 (3.16.14.15)
+    libv8 (3.16.14.19)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -249,8 +249,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    therubyracer (0.12.2)
-      libv8 (~> 3.16.14.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
       ref
     thor (0.20.0)
     thread_safe (0.3.6)
@@ -282,7 +282,7 @@ DEPENDENCIES
   database_cleaner
   diffy
   dotenv
-  factory_girl_rails (~> 4.0)
+  factory_bot_rails (~> 4.0)
   guard-rspec
   httparty
   jquery-rails
@@ -311,4 +311,4 @@ RUBY VERSION
    ruby 2.3.4p301
 
 BUNDLED WITH
-   1.14.6
+   1.16.3

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
 
   factory :page_snapshot do
     page { create(:page) }
@@ -9,12 +9,12 @@ FactoryGirl.define do
   end
 
   factory :slack_integration do
-    channel "#klaxon"
-    webhook_url "http://test-webhook.com/test-webhook"
+    channel { "#klaxon" }
+    webhook_url { "http://test-webhook.com/test-webhook" }
   end
 
   factory :sqs_integration do
-    queue_url "https://sqs.us-east-1.amazonaws.com/1234567890/klaxon-sqs-q-test"
+    queue_url { "https://sqs.us-east-1.amazonaws.com/1234567890/klaxon-sqs-q-test" }
   end
 
   factory :change do
@@ -27,13 +27,13 @@ FactoryGirl.define do
   end
 
   factory :page do
-    name "nyt homepage"
-    url "http://www.nytimes.com/"
-    css_selector "h2.story-heading"
+    name { "nyt homepage" }
+    url { "http://www.nytimes.com/" }
+    css_selector { "h2.story-heading" }
 
     trait :with_snapshots do
       transient do
-        snapshot_count 2
+        snapshot_count { 2 }
       end
       after(:create) do |page, evaluator|
         create_list(:page_snapshot, evaluator.snapshot_count, page: page)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,7 +37,7 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
   config.use_transactional_fixtures = false
 


### PR DESCRIPTION
Replacement for #164.

`FactoryGirl` has been renamed `FactoryBot`.

This PR also updates `therubyracer` (`0.12.3` is easier to install than `0.12.2`) and fixes all of the deprecation warnings in FactoryBot 4.11.0.