### PR TITLE
Switch from aws-sdk to aws-sdk-sqs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,7 @@ gem 'httparty'
 gem 'diffy'
 gem 'kramdown'
 
-# only used for alerting SQS.
-gem 'aws-sdk', '~> 2.0'
+gem 'aws-sdk-sqs', '~> 1.6'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,14 +41,17 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
-    aws-sdk (2.6.26)
-      aws-sdk-resources (= 2.6.26)
-    aws-sdk-core (2.6.26)
+    aws-eventstream (1.0.1)
+    aws-partitions (1.103.0)
+    aws-sdk-core (3.27.0)
+      aws-eventstream (~> 1.0)
+      aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.6.26)
-      aws-sdk-core (= 2.6.26)
-    aws-sigv4 (1.0.0)
+    aws-sdk-sqs (1.6.0)
+      aws-sdk-core (~> 3, >= 3.26.0)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.3)
     bcrypt (3.1.12)
     bindex (0.5.0)
     builder (3.2.3)
@@ -105,7 +108,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
-    jmespath (1.3.1)
+    jmespath (1.4.0)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -288,7 +291,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk (~> 2.0)
+  aws-sdk-sqs (~> 1.6)
   bcrypt (~> 3.1.12)
   byebug
   codeclimate-test-reporter

--- a/app/lib/sqs_notification.rb
+++ b/app/lib/sqs_notification.rb
@@ -1,5 +1,3 @@
-require 'aws-sdk'
-
 class SqsNotification
   def self.perform(queue_url, payload)
     client = Aws::SQS::Client.new(
@@ -11,16 +9,16 @@ class SqsNotification
 
     begin
       return client.send_message({
-        delay_seconds: 10, 
+        delay_seconds: 10,
         message_attributes: {
           "payload" => {
-            data_type: "String", 
-            string_value: json, 
+            data_type: "String",
+            string_value: json,
           }
-        }, 
-        message_body: json, 
-        queue_url: queue_url, 
-      }) 
+        },
+        message_body: json,
+        queue_url: queue_url,
+      })
     rescue Aws::SQS::Errors::ServiceError => e
       puts "Error sending SQS message to queue_url=#{queue_url} for payload=#{payload.to_json}; Error: #{e}"
       return false


### PR DESCRIPTION
As discussed in #159.

This should lower the memory profile of Klaxon - there's a lot of unneeded stuff in the old aws-sdk gem.