### PR TITLE
use DATABASE_URL in development as well

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,10 +5,7 @@ default: &default
 
 development:
   <<: *default
-  database: klaxon_development
-  username: <%= `whoami` %>
-  host: localhost
-  port: 5432
+  url: <%= ENV['DATABASE_URL'] || 'postgres://localhost/klaxon_development' %>
 
 test:
   <<: *default


### PR DESCRIPTION
by default the username will already be `whoami` so I don't think you need to specify that. you can test this by running `psql postgres://localhost/klaxon_development` locally and it will login via a user with the same name as `whoami`.

by default, the port is also 5432 so need to specify that

fixes #210 but haven't tested thoroughly