### PR TITLE
Add exclude selector option to ignore some changes

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -79,6 +79,6 @@ class PagesController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def page_params
-      params.require(:page).permit(:name, :url, :css_selector, subscriptions: [])
+      params.require(:page).permit(:name, :url, :css_selector, :exclude_selector, subscriptions: [])
     end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -37,7 +37,16 @@ class Page < ApplicationRecord
   end
 
   def match_text
-    document.css(self.css_selector).text
+    @match = document.css(self.css_selector)
+
+    if self.exclude_selector.present?
+      # Set the content of the exclude selector to the empty string
+      @match.css(self.exclude_selector).each do |node|
+        node.content = ""
+      end
+    end
+
+    @match.text
   end
 
   def match_html

--- a/app/models/page_snapshot.rb
+++ b/app/models/page_snapshot.rb
@@ -12,11 +12,11 @@ class PageSnapshot < ApplicationRecord
   end
 
   def match_text
-    @match = document.css(self.css_selector)
+    @match = document.css(self.page.css_selector)
 
-    if self.exclude_selector.present?
+    if self.page.exclude_selector.present?
       # Set the content of the exclude selector to the empty string
-      @match.css(self.exclude_selector).each do |node|
+      @match.css(self.page.exclude_selector).each do |node|
         node.content = ""
       end
     end

--- a/app/models/page_snapshot.rb
+++ b/app/models/page_snapshot.rb
@@ -12,7 +12,16 @@ class PageSnapshot < ApplicationRecord
   end
 
   def match_text
-    document.css(self.page.css_selector).text
+    @match = document.css(self.css_selector)
+
+    if self.exclude_selector.present?
+      # Set the content of the exclude selector to the empty string
+      @match.css(self.exclude_selector).each do |node|
+        node.content = ""
+      end
+    end
+
+    @match.text
   end
 
   def display_hash

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -27,6 +27,12 @@
             <%= f.input :css_selector, label: false, class: 'form-control', as: :string %>
           </div>
         </div>
+        <div class="form-group form-group-lg">
+          <label class="col-sm-1">Exclude selector</label>
+          <div class="col-sm-11">
+            <%= f.input :exclude_selector, label: false, class: 'form-control', as: :string %>
+          </div>
+        </div>
     </div>
   </div><!-- /.container -->
 </div>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -16,6 +16,11 @@
 </p>
 
 <p>
+  <strong>Exclude selector:</strong>
+  <%= @page.exclude_selector %>
+</p>
+
+<p>
   <strong>User:</strong>
   <%= @page.user_id %>
 </p>

--- a/data/help.md
+++ b/data/help.md
@@ -40,6 +40,8 @@ In the “[Watching](/watching/pages)” page you can manually add sites to moni
 
 Click on "Manually Watch and Item" on the right side of the heading. This will take you to directly to the Edit page for links. Here you can include the title, link to the site and the specific selector(s) you want to focus on.
 
+If you want to ignore changes within your chosen selector(s), enter another selector into the "Exclude selector" input.
+
 ## Understand what’s changed on a page
 
 Sometimes you want to see how the current version of a site compares to a version that you captured, say, six months ago. Because Klaxon stores each snapshot it finds of a site, this is fairly easy to do. You can reach the history of snapshots in a couple of ways. If it’s a site someone else in your newsroom is following, from the Feed, click on the latest snapshot you see for your site, which would say something like “GA Sec’y of State changed” or “The Marshall Project changed”. If it’s a site you added to Klaxon, from the “Watching” page, click on the “Latest snapshot” button next the site you want to explore. Either of these routes takes you to the most recent snapshot for that site.

--- a/db/migrate/20190223221320_add_exclude_selector_to_pages.rb
+++ b/db/migrate/20190223221320_add_exclude_selector_to_pages.rb
@@ -1,0 +1,5 @@
+class AddExcludeSelectorToPages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pages, :exclude_selector, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2017_05_26_193719) do
+ActiveRecord::Schema.define(version: 2019_02_23_221320) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2017_05_26_193719) do
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "exclude_selector"
     t.index ["user_id"], name: "index_pages_on_user_id"
   end
 


### PR DESCRIPTION
- Add exclude_selector to Page
- Adjust Page.match_text and PageSnapshot.match_text to use exclude_selector
- Expose exclude_selector in relevant views
- Tests
- Documentation

Fixes #239