### PR TITLE
Docker enhancements

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -9,3 +9,8 @@ services:
       DATABASE_URL: "postgres://postgres@database/klaxon"
       SECRET_KEY_BASE: "secret_key_base"
       ADMIN_EMAILS: "admin@news.org"
+
+#      KLAXON_CREATE_DB: 'false'
+#      KLAXON_MIGRATE_DB: 'false'
+#      KLAXON_CREATE_ADMIN: 'false'
+#      KLAXON_CRON_ENABLED: 'false'

--- a/rootfs/etc/cont-init.d/10-config.sh
+++ b/rootfs/etc/cont-init.d/10-config.sh
@@ -1,15 +1,32 @@
 #!/usr/bin/with-contenv bash
 
-# run klaxon startup commands
-cd /usr/src/app
-bundle exec rake db:create db:migrate || true
-bundle exec rake users:create_admin || true
+mkdir -p /config
 
+# set defaults
+KLAXON_CREATE_DB=${KLAXON_CREATE_DB:-true}
+KLAXON_MIGRATE_DB=${KLAXON_MIGRATE_DB:-true}
+KLAXON_CREATE_ADMIN=${KLAXON_CREATE_ADMIN:-true}
+KLAXON_CRON_ENABLED=${KLAXON_CRON_ENABLED:-true}
+
+# customizable klaxon startup commands
+cd /usr/src/app
+if [[ "${KLAXON_CREATE_DB}" = "true" ]]; then
+    bundle exec rake db:create || true
+fi
+if [[ "${KLAXON_MIGRATE_DB}" = "true" ]]; then
+    bundle exec rake db:migrate || true
+fi
+if [[ "${KLAXON_CREATE_ADMIN}" = "true" ]]; then
+    bundle exec rake users:create_admin || true
+fi
+if [[ "${KLAXON_CRON_ENABLED}" = "true" ]]; then
+    rm -rf /etc/services.d/cron/down
+else
+    touch /etc/services.d/cron/down
+fi
 
 
 # Setup cron to run klaxon every 15 mins.
-mkdir -p /config
-
 if [[ ! -f /config/klaxon-cron ]]; then
 
 cat > /config/klaxon-cron <<DELIM
@@ -21,13 +38,10 @@ cd /usr/src/app
 bundle exec rake check:all
 DELIM
 
-chmod +x /config/klaxon-cron
-
+    chmod +x /config/klaxon-cron
 fi
 
 if [[ ! -f /config/klaxon-crontab ]]; then
-
-echo "*/15 * * * * root /config/klaxon-cron > /proc/1/fd/1 2>&1" > /etc/cron.d/klaxon-crontab
-ln -s /config/klaxon-crontab /etc/cron.d/klaxon-crontab
-
+    echo "*/15 * * * * root /config/klaxon-cron > /proc/1/fd/1 2>&1" > /etc/cron.d/klaxon-crontab
+    ln -s /config/klaxon-crontab /etc/cron.d/klaxon-crontab
 fi


### PR DESCRIPTION
Follow up from discussion in #252 

This pull request adds the additional features to the official Docker image:
- Adds environmental variables that can be used to enable/disable each Rake task individually. 
- Adds environmental variable that can be used to enable/disable cron service.

These changes will allow users to migrate to the official Klaxon Docker image without changing their existing deployment workflows (`check:all` via host cron, manually trigger DB migration) while still ensuring that new users have a simple on-boarding experience. 

feedback appreciated

CC @GabeIsman @rdmurphy @chriszs 