### PR TITLE
Adds headless browser option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,9 @@ gem 'kramdown'
 
 gem 'aws-sdk-sqs', '~> 1.12'
 
+gem 'chromedriver-helper'
+gem 'watir'
+
 group :development, :test do
   gem 'byebug'
   gem 'rspec-rails', '~> 3.8'

--- a/app.json
+++ b/app.json
@@ -38,6 +38,9 @@
     },
     {
       "url": "https://github.com/gunpowderlabs/buildpack-ruby-rake-deploy-tasks"
+    },
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-google-chrome"
     }
   ]
 }

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -79,6 +79,6 @@ class PagesController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def page_params
-      params.require(:page).permit(:name, :url, :css_selector, :exclude_selector, subscriptions: [])
+      params.require(:page).permit(:name, :url, :css_selector, :exclude_selector, :use_headless_browser, subscriptions: [])
     end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -9,6 +9,35 @@ class Page < ApplicationRecord
 
   before_save :sanitize
 
+  def new_browser
+    options = Selenium::WebDriver::Chrome::Options.new
+
+    # make a directory for chrome if it doesn't already exist
+    chrome_dir = File.join Dir.pwd, %w(tmp chrome)
+    FileUtils.mkdir_p chrome_dir
+    user_data_dir = "--user-data-dir=#{chrome_dir}"
+    # add the option for user-data-dir
+    options.add_argument user_data_dir
+
+    # let Selenium know where to look for chrome if we have a hint from
+    # heroku. chromedriver-helper & chrome seem to work out of the box on osx,
+    # but not on heroku.
+    if chrome_bin = ENV["GOOGLE_CHROME_SHIM"]
+      options.add_argument "--no-sandbox"
+      options.binary = chrome_bin
+    end
+
+    # headless!
+    options.add_argument "--window-size=1200x600"
+    options.add_argument "--headless"
+    options.add_argument "--disable-gpu"
+
+    # make the browser
+    browser = Watir::Browser.new :chrome, options: options
+
+    browser
+  end
+
   def to_param
     [id, self.name.to_s.parameterize].join('-')
   end
@@ -25,11 +54,19 @@ class Page < ApplicationRecord
       return ''
     end
 
-    @html ||= begin
-      logger.info "downloading url=#{self.url} for page.id=#{self.id}"
-      dirty = Net::HTTP.get(URI(self.url.to_s))
-      SafeString.coerce(dirty)
+    logger.info "downloading url=#{self.url} for page.id=#{self.id}"
+
+    if self.use_headless_browser
+      browser = new_browser
+      browser.goto(self.url.to_s)
+      browser.element(:css => self.css_selector.to_s).wait_until(timeout: 10, &:present?)
+      dirty_html = browser.html
+      browser.close
+    else
+      dirty_html = Net::HTTP.get(URI(self.url.to_s))
     end
+
+    SafeString.coerce(dirty_html)
   end
 
   def document

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -33,6 +33,12 @@
             <%= f.input :exclude_selector, label: false, class: 'form-control', as: :string %>
           </div>
         </div>
+        <div class="form-group form-group-lg">
+          <label class="col-sm-1">Use headless browser</label>
+          <div class="col-sm-11">
+            <%= f.input :use_headless_browser, label: false, class: 'form-control', as: :boolean %>
+          </div>
+        </div>
     </div>
   </div><!-- /.container -->
 </div>

--- a/db/migrate/20200322011340_add_headless_browser_to_pages.rb
+++ b/db/migrate/20200322011340_add_headless_browser_to_pages.rb
@@ -1,0 +1,5 @@
+class AddHeadlessBrowserToPages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pages, :use_headless_browser, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_23_221320) do
+ActiveRecord::Schema.define(version: 2020_03_22_011340) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2019_02_23_221320) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "exclude_selector"
+    t.boolean "use_headless_browser"
     t.index ["user_id"], name: "index_pages_on_user_id"
   end
 


### PR DESCRIPTION
This adds the option to scrape the page using a headless Chrome browser. It will wait 10 seconds for the CSS selector to exist before timing out and moving on (we can reduce this, but I figured 10 seconds was a good place to start). I've also added the necessary Heroku buildpack and tested it in Heroku.

To enable headless scraping, you just need to check this box:

![image](https://user-images.githubusercontent.com/2408118/77258531-8e134600-6c51-11ea-93bb-b9f10b95dc77.png)

That's it!