### PR TITLE
adds more detailed steps for spinning up dockerized version locally

### DIFF
--- a/docker_example/README.md
+++ b/docker_example/README.md
@@ -1,0 +1,23 @@
+## Modify environment variables
+
+edit env_local.list (found in the docker_example directory) and use your own values for things like database_url, admin_email, etc. 
+
+
+## Build the image from The Marshall Project's github repo (using the develop branch)
+
+`docker build --network host -t klaxon https://github.com/themarshallproject/klaxon.git#develop`
+
+
+## Run it on your local machine as a daemon
+
+cd into the docker_example directory in this repo and run the following. You only need to be in this directory because we used a relative path to the env_local.list file.
+
+`docker run -p 8885:3000 --name klaxon_local --env-file ./env_local.list --restart unless-stopped -d klaxon`
+
+
+## View the app
+
+Go to your browser and hit `127.0.0.1:8885` .
+
+
+

--- a/docker_example/env_local.list
+++ b/docker_example/env_local.list
@@ -1,0 +1,15 @@
+#We set the postgres url/IP addres here and include username and password in the url
+DATABASE_URL=postgres://USERNAME:PASSWORD@192.168.10.40/klaxon
+"ADMIN_EMAILS=someuser@companyname.com
+RAILS_ENV=production
+# We're using the same production secret_key_base value used in non-docker version of the app
+SECRET_KEY_BASE=secret_key_value_here
+# postfix doesn't need to be installed for this to work.
+SMTP_PROVIDER=POSTFIX
+# set this to the value of your own smpt server
+POSTFIX_ADDRESS=smtp-xxx.companyname.com
+POSTFIX_PORT=25
+POSTFIX_DOMAIN=companyname.com
+#We have this set to false because we are handling ssl redirect in our nginx vhost. Leaving it true causes "too many redirects" error. If running on your local machine, this should also be set to false because you probably don't have an ssl cert set up for localhost.
+KLAXON_FORCE_SSL=false
+KLAXON_COMPILE_ASSETS=true


### PR DESCRIPTION
Includes detailed set of instructions for spinning the app up via docker (using the Marshall Project's github repo). Assuming you have docker and a local postgres db available, this might be (in my humble opinion) the easiest way to spin Klaxon up locally. (It would require just a few tweaks for production)