### PR TITLE
Ruby Version Update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.5
+FROM ruby:2.5.7
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1


### PR DESCRIPTION
Fixes "Your Ruby version is 2.4.5, but your Gemfile specified 2.5.7" error