### PR TITLE
Make db:create optional

### DIFF
--- a/rootfs/etc/cont-init.d/10-config.sh
+++ b/rootfs/etc/cont-init.d/10-config.sh
@@ -2,7 +2,8 @@
 
 # run klaxon startup commands
 cd /usr/src/app
-bundle exec rake db:create db:migrate || true
+bundle exec rake db:create || true
+bundle exec rake db:migrate || true
 bundle exec rake users:create_admin || true
 
 


### PR DESCRIPTION
Outside of heroku, in other environments - db creation permissions are rarely granted.
Keeping db:create and db:migrate in separate lines ensures that the migration runs in case the database is already created.