### PR TITLE
Remove sdoc from project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'jquery-rails'
 gem 'turbolinks'
 gem 'bootsnap', require: false
 gem 'coffee-rails'
-gem 'sdoc', '~> 2.3.1', group: :doc
 
 gem 'rack-cache'
 gem 'bcrypt', '~> 3.1.18'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,7 +256,6 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rdoc (6.3.3)
     rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -293,8 +292,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sdoc (2.3.1)
-      rdoc (>= 5.0, < 6.4.0)
     shellany (0.0.1)
     simple_form (5.1.0)
       actionpack (>= 5.2)
@@ -375,7 +372,6 @@ DEPENDENCIES
   rspec-github
   rspec-rails
   sass-rails (~> 5.0)
-  sdoc (~> 2.3.1)
   simple_form (~> 5.0)
   sinatra
   spring


### PR DESCRIPTION
Dependabot is mad about the latest version of this — AFAICT Klaxon has _never_ used this gem for anything. It just used to ship with Rails, so it has shipped with Klaxon since the project was created because of that legacy. Rails doesn't include it anymore, either.

Better to just purge it, I think.