### PR TITLE
Remove coffee-rails from project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem 'dotenv'
 gem 'jquery-rails'
 gem 'turbolinks'
 gem 'bootsnap', require: false
-gem 'coffee-rails'
 gem 'sdoc', '~> 2.3.1', group: :doc
 
 gem 'rack-cache'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,13 +79,6 @@ GEM
     codeclimate-test-reporter (1.0.9)
       simplecov (<= 0.13)
     coderay (1.1.3)
-    coffee-rails (5.0.0)
-      coffee-script (>= 2.2.0)
-      railties (>= 5.2.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
@@ -353,7 +346,6 @@ DEPENDENCIES
   bootsnap
   byebug
   codeclimate-test-reporter
-  coffee-rails
   database_cleaner
   diffy
   dotenv


### PR DESCRIPTION
Same deal as #599 — we aren't using `.coffee` files anywhere, so there's no reason for this to be here.