### PR TITLE
Remove rails_12factor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem 'bootsnap', require: false
 gem 'rack-cache'
 gem 'bcrypt', '~> 3.1.18'
 gem 'puma', '~> 5.6'
-gem 'rails_12factor'
 
 gem 'simple_form', '~> 5.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,11 +234,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (6.0.3.6)
       actionpack (= 6.0.3.6)
       activesupport (= 6.0.3.6)
@@ -360,7 +355,6 @@ DEPENDENCIES
   rack-cache
   rails (~> 6.0.0)
   rails-controller-testing
-  rails_12factor
   rspec-github
   rspec-rails
   sass-rails (~> 5.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,6 +80,12 @@ Rails.application.configure do
   # config.action_mailer.delivery_method = :postmark
   # config.action_mailer.postmark_settings = { :api_token => ENV['POSTMARK_API_TOKEN'] }
 
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger  = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
+
   provider  = (ENV["SMTP_PROVIDER"] || "SENDGRID").to_s
   address   = ENV["#{provider}_ADDRESS"] || "smtp.sendgrid.net"
   # if you use SES as your SMTP provider, then your username and password are actually your AWS credentials.


### PR DESCRIPTION
Per the `rails12_factor` README this gem [hasn't been required since Rails 5](https://github.com/heroku/rails_12factor#migrating-to-rails-5). Away it goes!