### PR TITLE
Remove unused changes stylesheet_link_tag

### DIFF
--- a/app/views/page_snapshots/html.html.erb
+++ b/app/views/page_snapshots/html.html.erb
@@ -1,5 +1,3 @@
-<%= stylesheet_link_tag "changes", media: "all" %>
-
 <div class="klax-section klax-topper">
   <div class="container">
     <div class="row">


### PR DESCRIPTION
Thanks for the cool project. This is my first time working with it.

Snapshot pages throw an exception locally with the below. It does not appear that this stylesheet is needed as the page renders okay without any "changes" stylesheet. This removes reference to it.

<img width="1018" alt="Screen Shot 2023-03-20 at 5 09 24 PM" src="https://user-images.githubusercontent.com/3457341/226486136-0b036081-ce47-4a07-bbb8-4fb265cdad48.png">
