### PR TITLE
make cookie expiration available as an env var, COOKIE_EXPIRATION_DAYS

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,7 +21,7 @@ class SessionsController < ApplicationController
       if user[:expired]
         redirect_to expired_token_path(user[:user].id)
       else
-        cookies.signed[:user_id] = { value: user.id, expires: 7.days.from_now, httponly: true }
+        cookies.signed[:user_id] = { value: user.id, expires: (ENV['COOKIE_EXPIRATION_DAYS'] || 7).days.from_now, httponly: true }
         redirect_to root_path
       end
     else


### PR DESCRIPTION
Hi y'all -- Github informs me it's been six years since I interacted with this repo :) Hope everyone's doing all right.

I dusted off my old Ruby skills to submit this pull request which will let cookie expiration be set with an env var. We have an internal setup that's gated by the SSO platform and the firewall, so we're relying on the built-in auth exclusively for making sure emails go to the right place. Please let me know if this is a bad idea!