### PR TITLE
refactor: add example env file for easier environment variable management

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,49 @@
+version: '3'
+
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+
+    volumes:
+      - ../..:/workspaces:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+    env_file:
+      - .env.local
+
+  db:
+    image: postgres:latest
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./create-db-user.sql:/docker-entrypoint-initdb.d/create-db-user.sql
+    env_file:
+      - .env.local
+      # Your config/database.yml should use the user and password you set here,
+      # and host "db" (as that's the name of this service). You can use whatever
+      # database name you want. Use `bin/rails db:prepare` to create the database.
+      #
+      # Example:
+      #
+      #  development:
+      #    <<: *default
+      #    host: db
+      #    username: postgres
+      #    password: postgres
+      #    database: myapp_development
+
+    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+volumes:
+  postgres-data:
+

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,28 @@
+# App settings
+RACK_ENV=development
+RAILS_ENV=development
+HOST='localhost:3000'
+PORT=3000
+
+# DB settings needed only for db creation
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=klaxon
+POSTGRES_HOST=db
+
+# Postgres URI pattern is postgresql://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]
+DATABASE_URL="postgres://postgres:postgres@db:5432/klaxon"
+SECRET_KEY_BASE="secret_key_base"
+ADMIN_EMAILS="admin@news.org" # comma-separated list of email addresses
+
+# Email config if using Sendgrid
+SENDGRID_USERNAME=
+SENDGRID_PASSWORD=
+
+# Email config if using Amazon SES
+SMTP_PROVIDER= # SES
+SES_ADDRESS=
+SES_USERNAME=
+SES_PASSWORD=
+SES_DOMAIN=
+MAILER_FROM_ADDRESS=

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ snapshots
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+.env*
+!.env.*.example

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -24,14 +24,13 @@ gem install bundler
 bundle install
 ```
 
-In order to be allowed to login to Klaxon once it's running on your machine, it'll need to know that your email address is. Create a file named `.env` and paste in these two items:
+In order to be allowed to login to Klaxon once it's running on your machine, it'll need to know that your email address is. Create an env file for local development like so:
 
 ```
-ADMIN_EMAILS="my_awesome_email@gmail.com"
-HOST='localhost:5000'
+cp .env.local.example .env.local
 ```
 
-Feel free to substitute in your email address. In development, Klaxon doesn't actually send emails locally, so a real address is not required.
+Feel free to substitute in your email address in `ADMIN_EMAILS`. In development, Klaxon doesn't actually send emails locally, so a real address is not required. But, those will be the addresses used to log into the app.
 
 Now that's set, you'll run a couple of commands for Rails to create Klaxon's database on your machine.
 


### PR DESCRIPTION
This is purely meant as a developer experience enhancement. Rather than referencing different environment variables in different files, it can sometimes be a bit easier to copy the contents of an example env file into an actual env file and go from there.

Worth noting: this is part of my team's effort to sort out our guidelines for contributing back to open source projects we stand up for The Post's newsroom. This is just a small test case for our first go at it with Klaxon.