### PR TITLE
Large record deletion timeout fix, fixes #699

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem 'aws-sdk-sqs', '~> 1.64'
 
 gem 'miss_hannigan'
 
+gem 'miss_hannigan'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem 'kramdown'
 
 gem 'aws-sdk-sqs', '~> 1.64'
 
+gem 'miss_hannigan'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,8 +69,8 @@ GEM
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     aws-eventstream (1.2.0)
-    aws-partitions (1.831.0)
-    aws-sdk-core (3.185.0)
+    aws-partitions (1.834.0)
+    aws-sdk-core (3.185.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
@@ -89,7 +89,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    css_parser (1.14.0)
+    css_parser (1.16.0)
       addressable
     dartsass-rails (0.5.0)
       railties (>= 6.0.0)
@@ -110,21 +110,18 @@ GEM
       rails (>= 3.0.0)
     dotenv (2.8.1)
     erubi (1.12.0)
-    execjs (2.8.1)
+    execjs (2.9.1)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    ffi (1.15.5)
+    ffi (1.16.3)
     formatador (1.1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-protobuf (3.23.3-aarch64-linux)
-    google-protobuf (3.23.3-arm64-darwin)
-    google-protobuf (3.23.3-x86_64-darwin)
-    google-protobuf (3.23.3-x86_64-linux)
-    guard (2.18.0)
+    google-protobuf (3.24.4-x86_64-darwin)
+    guard (2.18.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
       lumberjack (>= 1.0.12, < 2.0)
@@ -146,8 +143,9 @@ GEM
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
-    irb (1.6.4)
-      reline (>= 0.3.0)
+    irb (1.8.1)
+      rdoc
+      reline (>= 0.3.8)
     jmespath (1.6.2)
     jquery-rails (4.6.0)
       rails-dom-testing (>= 1, < 3)
@@ -166,7 +164,7 @@ GEM
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    lumberjack (1.2.8)
+    lumberjack (1.2.9)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -176,12 +174,14 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.5)
     minitest (5.20.0)
-    msgpack (1.7.0)
+    miss_hannigan (0.1.2)
+      rails (>= 5.1)
+    msgpack (1.7.2)
     multi_xml (0.6.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     nenv (0.3.0)
-    net-imap (0.3.7)
+    net-imap (0.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -191,13 +191,7 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.15.4-aarch64-linux)
-      racc (~> 1.4)
-    nokogiri (1.15.4-arm64-darwin)
-      racc (~> 1.4)
     nokogiri (1.15.4-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -214,6 +208,8 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    psych (5.1.0)
+      stringio
     public_suffix (5.0.3)
     puma (6.4.0)
       nio4r (~> 2.0)
@@ -259,7 +255,9 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    reline (0.3.3)
+    rdoc (6.5.0)
+      psych (>= 4.0.0)
+    reline (0.3.9)
       io-console (~> 0.5)
     rexml (3.2.6)
     rspec (3.12.0)
@@ -273,7 +271,7 @@ GEM
       rspec-support (~> 3.12.0)
     rspec-github (2.4.0)
       rspec-core (~> 3.0)
-    rspec-mocks (3.12.5)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-rails (6.0.3)
@@ -284,15 +282,9 @@ GEM
       rspec-expectations (~> 3.12)
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
-    rspec-support (3.12.0)
+    rspec-support (3.12.1)
     ruby2_keywords (0.0.5)
-    sass-embedded (1.63.4-aarch64-linux-gnu)
-      google-protobuf (~> 3.23)
-    sass-embedded (1.63.4-arm64-darwin)
-      google-protobuf (~> 3.23)
-    sass-embedded (1.63.4-x86_64-darwin)
-      google-protobuf (~> 3.23)
-    sass-embedded (1.63.4-x86_64-linux-gnu)
+    sass-embedded (1.69.1-x86_64-darwin)
       google-protobuf (~> 3.23)
     shellany (0.0.1)
     simple_form (5.2.0)
@@ -303,17 +295,18 @@ GEM
       rack (~> 2.2, >= 2.2.4)
       rack-protection (= 3.1.0)
       tilt (~> 2.0)
-    sprockets (4.2.0)
+    sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
     sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    stringio (3.0.8)
     terser (1.1.18)
       execjs (>= 0.3.0, < 3)
     thor (1.2.2)
-    tilt (2.2.0)
+    tilt (2.3.0)
     timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -329,13 +322,10 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.6.11)
+    zeitwerk (2.6.12)
 
 PLATFORMS
-  aarch64-linux
-  arm64-darwin-22
   x86_64-darwin-22
-  x86_64-linux
 
 DEPENDENCIES
   aws-sdk-sqs (~> 1.64)
@@ -353,6 +343,7 @@ DEPENDENCIES
   jwt
   kramdown
   letter_opener
+  miss_hannigan
   pg (~> 1.5)
   premailer-rails
   puma (~> 6.4)
@@ -371,4 +362,4 @@ RUBY VERSION
    ruby 3.1.4p223
 
 BUNDLED WITH
-   2.4.12
+   2.4.20

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,7 +1,7 @@
 class Page < ApplicationRecord
   belongs_to :user
 
-  has_many :page_snapshots, dependent: :destroy
+  has_many :page_snapshots, dependent: :nullify_then_purge
 
   attr_accessor :subscriptions # Gets set in controller on update/create
   after_create :update_subscriptions


### PR DESCRIPTION
Adds [a gem](https://github.com/sutrolabs/miss_hannigan/tree/main) that allows for a faster deletion of child records (page snapshots) when deleting a parent record (page). This problem was leading to timeouts when trying to delete pages that had many snapshots, and the makers of the gem seem to capture the problem well [in this post](https://medium.com/@natekontny/handling-slow-cascading-deletes-in-rails-f2581f34c186).

This change does cause one test to fail (`deletes associated snapshots and changes upon deletion`), but given that RoR is not my forte, I left the test unchanged.